### PR TITLE
Support for one-shot generation of MS-SQL database.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,3 +6,8 @@ packages:
   ./dbrecord-postgres-simple
   ./dbrecord-sqlite-simple
   ./dbrecord-mssql-odbc
+
+source-repository-package
+    type: git
+    location: https://github.com/byteally/mssql-odbc.git
+    tag: 85658c0dda9bb257c3094c3f040b41e0ba96f580

--- a/dbrecord-migration/src/DBRecord/Migration.hs
+++ b/dbrecord-migration/src/DBRecord/Migration.hs
@@ -1328,7 +1328,8 @@ class ( BaseDatabase db ver
       , SingE (GetPMT (Rep db))
       , All (SingCtxBase db ver) (BaseTables db ver)
       , AllBaseUDCtx db ver (BaseTypes db ver)
-      , SingI (BaseTypes db ver)        
+      , SingI (BaseTypes db ver)  
+      , SingI (DB db)      
       ) => SingCtxBaseDb db ver where
 
 instance ( BaseDatabase db ver
@@ -1345,6 +1346,7 @@ instance ( BaseDatabase db ver
 
          , AllBaseUDCtx db ver (BaseTypes db ver)
          , SingI (BaseTypes db ver)
+         , SingI (DB db)
          ) => SingCtxBaseDb db ver where  
 
 type family AllBaseUDCtx db ver tys :: Constraint where
@@ -1403,6 +1405,7 @@ baseDatabaseInfo pdb pver =
   in mkDatabaseInfo (mkEntityName (coerce (fromSing (sing :: Sing (GetPMT (Rep db)))))
                                        (fromSing (sing :: Sing (BaseSchema db ver)))
                  ) btys 0 0 (coerce (baseTableInfos pdb pver (sing :: Sing (BaseTables db ver))))
+                 (fromSing (sing :: Sing (DB db)))
 
 baseTableInfos :: (All (SingCtxBase db ver) xs) => Proxy (db :: *) -> Proxy (ver :: Nat) -> Sing (xs :: [TypeName Symbol]) -> [TableInfo]
 baseTableInfos pdb pver (SCons st@(STypeName {}) sxs) =

--- a/dbrecord-mssql-odbc/dbrecord-mssql-odbc.cabal
+++ b/dbrecord-mssql-odbc/dbrecord-mssql-odbc.cabal
@@ -55,20 +55,43 @@ library
 
   default-language:    Haskell2010
 
-test-suite dbrecord-mssql-odbc-test
+-- test-suite dbrecord-mssql-odbc-test
+--   type:                exitcode-stdio-1.0
+--   hs-source-dirs:      test
+--   main-is:             Main.hs
+--   build-depends:       base
+--                      , text
+--                      , dbrecord
+--                      , dbrecord-mssql-odbc
+--                      , odbc
+--                     --  , hspec >= 2.6.0
+--                      , mtl
+--                      , postgresql-simple >= 0.5
+--                     --  , mysql-haskell >= 0.8
+--                     --  , mongoDB
+                     
+--   other-modules:       
+--   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
+--   default-language:    Haskell2010
+
+
+test-suite dbrecord-mssql-odbc-sqlexpr-test
   type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
+  hs-source-dirs:      sqlexpr-test
   main-is:             Main.hs
   build-depends:       base
                      , text
                      , dbrecord
-                    --  , dbrecord-mssql-odbc
+                     , dbrecord-mssql-odbc
                      , odbc
-                     , hspec
+                    --  , hspec >= 2.6.0
                      , mtl
-                     , postgresql-simple >= 0.5
-                     , mysql-haskell >= 0.8
-                     , mongoDB
+                    --  , postgresql-simple >= 0.5
+                    --  , mysql-haskell >= 0.8
+                    --  , mongoDB
+                     , attoparsec
+                     , tasty
+                     , tasty-hunit
   other-modules:       
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010

--- a/dbrecord-mssql-odbc/dbrecord-mssql-odbc.cabal
+++ b/dbrecord-mssql-odbc/dbrecord-mssql-odbc.cabal
@@ -21,6 +21,7 @@ library
                        DBRecord.MSSQL.Internal.PrettyDDL
                        DBRecord.MSSQL.Internal.Query
                        DBRecord.MSSQL.Internal.Types
+                       DBRecord.MSSQL.Internal.Reify
                                          
   build-depends:       base              >= 4.7 && < 5
                      , dbrecord

--- a/dbrecord-mssql-odbc/dbrecord-mssql-odbc.cabal
+++ b/dbrecord-mssql-odbc/dbrecord-mssql-odbc.cabal
@@ -42,7 +42,7 @@ library
                      , mssql-odbc
                      , resource-pool      == 0.2.*
                      , vector             == 0.12.*
-                     , dbrecord-migration == 0.1.*
+                    --  , dbrecord-migration == 0.1.*
                      , profunctors
                      , unordered-containers >= 0.2
                      -- , uniplate             >= 1.6

--- a/dbrecord-mssql-odbc/dbrecord-mssql-odbc.cabal
+++ b/dbrecord-mssql-odbc/dbrecord-mssql-odbc.cabal
@@ -43,12 +43,14 @@ library
                      , vector             == 0.12.*
                      , dbrecord-migration == 0.1.*
                      , profunctors
-                     -- , unordered-containers >= 0.2
+                     , unordered-containers >= 0.2
                      -- , uniplate             >= 1.6
                      -- , scientific        >= 0.3 
                      -- , binary            >= 0.8
                      -- , base64-bytestring >= 1.0
                      -- , time              == 1.6.*
+                     , hashable
+                     , odbc
 
   default-language:    Haskell2010
 
@@ -59,7 +61,8 @@ test-suite dbrecord-mssql-odbc-test
   build-depends:       base
                      , text
                      , dbrecord
-                     , dbrecord-mssql-odbc
+                    --  , dbrecord-mssql-odbc
+                     , odbc
                      , hspec
                      , mtl
                      , postgresql-simple >= 0.5

--- a/dbrecord-mssql-odbc/dbrecord-mssql-odbc.cabal
+++ b/dbrecord-mssql-odbc/dbrecord-mssql-odbc.cabal
@@ -51,7 +51,6 @@ library
                      -- , base64-bytestring >= 1.0
                      -- , time              == 1.6.*
                      , hashable
-                     , odbc
 
   default-language:    Haskell2010
 

--- a/dbrecord-mssql-odbc/sqlexpr-test/Main.hs
+++ b/dbrecord-mssql-odbc/sqlexpr-test/Main.hs
@@ -1,0 +1,348 @@
+{-# LANGUAGE DataKinds, TypeApplications, DeriveGeneric, KindSignatures, TypeFamilies, MultiParamTypeClasses, GeneralizedNewtypeDeriving, OverloadedStrings, FlexibleContexts, DuplicateRecordFields #-}
+
+
+module Main where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Data.Attoparsec.Text as A
+-- import Data.Either
+import DBRecord.MSSQL.Internal.Sql.Parser
+import DBRecord.Internal.Sql.DML
+import Data.Text as T
+
+
+main :: IO ()
+main = defaultMain tests 
+
+tests :: TestTree
+tests = testGroup "Tests"
+  [ testCase "2+2=4" $
+      2+2 @?= 4
+--   , testCase "7 is even" $
+--       assertBool "Oops, 7 is odd" (even 7)
+
+  , testCase "Binary Operator Expression" $ 
+      (@=?) 
+        (parseIntoSqlExpr "([employee_id]>=(1))")
+        (ParensSqlExpr (BinSqlExpr OpGtEq (ColumnSqlExpr (SqlColumn ["employee_id"])) (ParensSqlExpr (ConstSqlExpr (IntegerSql 1)))))
+
+
+    -- The following result is not really correct. We need to change the AST (FunSqlExpr)
+  , testCase "Binary Operator Function Call and GtEq comparison" $ 
+      (@=?)
+        (parseIntoSqlExpr "([dbo].[CheckFnctn]()>=(1))")
+        (ParensSqlExpr (BinSqlExpr OpGtEq (FunSqlExpr "dboCheckFnctn" []) (ParensSqlExpr (ConstSqlExpr (IntegerSql 1)))))
+
+
+-- Binary Bitwise Operators
+  , testCase "Binary Bitwise AND" $ 
+      (@=?)
+        (parseIntoSqlExpr "12 & 20")
+        (BinSqlExpr OpBitAnd (ConstSqlExpr (IntegerSql 12)) (ConstSqlExpr (IntegerSql 20)))
+  , testCase "Binary Bitwise OR" $ 
+      (@=?)
+        (parseIntoSqlExpr "170 | 75")
+        (BinSqlExpr OpBitOr (ConstSqlExpr (IntegerSql 170)) (ConstSqlExpr (IntegerSql 75)))
+  , testCase "Binary Bitwise NOT" $ 
+      (@=?)
+        (parseIntoSqlExpr "~ 170")
+        (PrefixSqlExpr OpBitwiseNot (ConstSqlExpr (IntegerSql 170)))
+
+
+-- Arithmetic Operators
+
+  , testCase "Addition" $ 
+      (@=?)
+        (parseIntoSqlExpr "2 + 2")
+        (BinSqlExpr OpPlus (ConstSqlExpr (IntegerSql 2)) (ConstSqlExpr (IntegerSql 2)))
+
+  , testCase "Subtraction" $ 
+      (@=?)
+        (parseIntoSqlExpr "3 - 1")
+        (BinSqlExpr OpMinus (ConstSqlExpr (IntegerSql 3)) (ConstSqlExpr (IntegerSql 1)))
+
+  , testCase "Multiplication" $ 
+      (@=?)
+        (parseIntoSqlExpr "3 * 3")
+        (BinSqlExpr OpMul (ConstSqlExpr (IntegerSql 3)) (ConstSqlExpr (IntegerSql 3)))
+ 
+  , testCase "Division" $ 
+      (@=?)
+        (parseIntoSqlExpr "10 / 5")
+        (BinSqlExpr OpDiv (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 5)))
+
+  , testCase "Modulo" $ 
+      (@=?)
+        (parseIntoSqlExpr "10 % 2")
+        (BinSqlExpr OpMod (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 2)))
+
+
+-- Logical Operators
+
+--   , testCase "Logical ALL" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+  , testCase "Logical AND without parenthesis (Precedence test)" $ 
+      (@=?)
+        (parseIntoSqlExpr "10 > 5 AND 20 > 30")
+        (BinSqlExpr OpAnd (BinSqlExpr OpGt (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 5)) ) (BinSqlExpr OpGt (ConstSqlExpr (IntegerSql 20)) (ConstSqlExpr (IntegerSql 30))))
+
+  , testCase "Logical AND" $ 
+      (@=?)
+        (parseIntoSqlExpr "(10>3) AND (4>1)")
+        (BinSqlExpr OpAnd (ParensSqlExpr (BinSqlExpr OpGt (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 3)))) (ParensSqlExpr (BinSqlExpr OpGt (ConstSqlExpr (IntegerSql 4)) (ConstSqlExpr (IntegerSql 1)))))
+
+--   , testCase "Logical ANY" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "Logical BETWEEN" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "Logical EXISTS" $  -- SubQuery
+--       (@=?)
+--         (parseIntoSqlExpr "")
+        -- ()
+
+--   , testCase "Logical IN" $      -- SubQuery
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "Logical SOME" $    -- SubQuery
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+
+
+--TODO : 
+--   , testCase "Logical LIKE" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "'hellowmfcsaed' LIKE 'hello%'")
+--         ()
+
+  , testCase "Logical NOT" $ 
+      (@=?)
+        (parseIntoSqlExpr "NOT (20 > 30)")
+        (PrefixSqlExpr OpNot (ParensSqlExpr (BinSqlExpr OpGt (ConstSqlExpr (IntegerSql 20)) (ConstSqlExpr (IntegerSql 30)))))
+
+  , testCase "Logical OR without parenthesis (precedence test)" $ 
+      (@=?)
+        (parseIntoSqlExpr "10 > 5 OR 20 > 30")
+        (BinSqlExpr OpOr (BinSqlExpr OpGt (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 5)) ) (BinSqlExpr OpGt (ConstSqlExpr (IntegerSql 20)) (ConstSqlExpr (IntegerSql 30))))
+
+  , testCase "Logical OR" $ 
+      (@=?)
+        (parseIntoSqlExpr "(10 > 5) OR (20 > 30)")
+        (BinSqlExpr OpOr (ParensSqlExpr (BinSqlExpr OpGt (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 5)))) (ParensSqlExpr (BinSqlExpr OpGt (ConstSqlExpr (IntegerSql 20)) (ConstSqlExpr (IntegerSql 30)))))
+
+
+
+
+-- Comparison Operators
+
+  , testCase "Equals" $ 
+      (@=?)
+        (parseIntoSqlExpr "10 = 11")
+        (BinSqlExpr OpEq (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 11)))
+
+  , testCase "Greater than" $ 
+      (@=?)
+        (parseIntoSqlExpr "10 > 9")
+        (BinSqlExpr OpGt (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 9)))
+
+  , testCase "Less than" $ 
+      (@=?)
+        (parseIntoSqlExpr "8 < 9")
+        (BinSqlExpr OpLt (ConstSqlExpr (IntegerSql 8)) (ConstSqlExpr (IntegerSql 9)))
+
+  , testCase "Greater than or equal to " $ 
+      (@=?)
+        (parseIntoSqlExpr "10 >= 3")
+        (BinSqlExpr OpGtEq (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 3)))
+
+  , testCase "Less than or equal to" $ 
+      (@=?)
+        (parseIntoSqlExpr "3 <= 10")
+        (BinSqlExpr OpLtEq (ConstSqlExpr (IntegerSql 3)) (ConstSqlExpr (IntegerSql 10)))
+
+  , testCase "Not equal to" $ 
+      (@=?)
+        (parseIntoSqlExpr "10 <> 11")
+        (BinSqlExpr OpNotEq (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 11)))
+
+  , testCase "Not equal to (non-ISO)" $ 
+      (@=?)
+        (parseIntoSqlExpr "10 != 11")
+        (BinSqlExpr OpNotEq (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 11)))
+
+
+  , testCase "Not Less than (non-ISO)" $ 
+      (@=?)
+        (parseIntoSqlExpr "10 !< 8")
+        (BinSqlExpr OpNotLt (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 8)))
+
+  , testCase "Not Greater than (non-ISO)" $ 
+      (@=?)
+        (parseIntoSqlExpr "10 !> 12")
+        (BinSqlExpr OpNotGt (ConstSqlExpr (IntegerSql 10)) (ConstSqlExpr (IntegerSql 12)))
+
+
+-- String Operators (String matching)
+
+  , testCase "String match Wildcard %" $ 
+      (@=?)
+        (parseIntoSqlExpr "'hello%'")
+        (ConstSqlExpr (StringSql "hello%"))
+
+  , testCase "String match any char in range - Wildcard []" $ 
+      (@=?)
+        (parseIntoSqlExpr "'hello[a-e]'")
+        (ConstSqlExpr (StringSql "hello[a-e]"))
+
+  , testCase "String do not match char - Wildcard [^]" $ 
+      (@=?)
+        (parseIntoSqlExpr "'h[^e]llo'")
+        (ConstSqlExpr (StringSql "h[^e]llo"))
+
+  , testCase "String match Wildcard single character" $ 
+      (@=?)
+        (parseIntoSqlExpr "'h_llo'")
+        (ConstSqlExpr (StringSql "h_llo"))
+
+
+  ]
+ where 
+    parseIntoSqlExpr :: Text -> SqlExpr
+    parseIntoSqlExpr txt = either parsePanic id . parseOnly sqlExpr $ txt
+
+    parsePanic :: String -> SqlExpr 
+    parsePanic e = error $ "Panic while parsing: " ++ show e -- ++ " , " ++ "while parsing " ++ show t
+ 
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()
+
+--   , testCase "" $ 
+--       (@=?)
+--         (parseIntoSqlExpr "")
+--         ()

--- a/dbrecord-mssql-odbc/src/DBRecord/MSSQL/Internal/PrettyDDL.hs
+++ b/dbrecord-mssql-odbc/src/DBRecord/MSSQL/Internal/PrettyDDL.hs
@@ -11,7 +11,7 @@ import Text.PrettyPrint.HughesPJ (Doc, (<+>), text,
                                   (<>))
 import Prelude hiding ((<>))
 import DBRecord.Internal.DBTypes (DBType (DBTypeName))
-import DBRecord.Migration (ChangeSet (..))
+-- import DBRecord.Migration (ChangeSet (..))
 import qualified Data.Text as T
 import DBRecord.MSSQL.Internal.Sql.Pretty
 import DBRecord.Internal.Sql.SqlGen
@@ -232,10 +232,10 @@ ppAlterAttr (ChangeAttrType ty) =
 renderDDL :: PrimDDL -> String
 renderDDL = render . ppPrimDDL
 
-renderChangeSets :: [ChangeSet] -> String
-renderChangeSets =
-  unlines . map renderChangeSet 
+-- renderChangeSets :: [ChangeSet] -> String
+-- renderChangeSets =
+--   unlines . map renderChangeSet 
 
-renderChangeSet :: ChangeSet -> String
-renderChangeSet =
-  unlines . map renderDDL . statements
+-- renderChangeSet :: ChangeSet -> String
+-- renderChangeSet =
+--   unlines . map renderDDL . statements

--- a/dbrecord-mssql-odbc/src/DBRecord/MSSQL/Internal/Reify.hs
+++ b/dbrecord-mssql-odbc/src/DBRecord/MSSQL/Internal/Reify.hs
@@ -245,7 +245,7 @@ toDatabaseInfo hints dbn eis cols chks defs pk uqs fks =
                                       , _ignoredCols    = ()
                                       }
                        ) tabNs
-  in mkDatabaseInfo dbt types 0 0 (coerce tabInfos)
+  in mkDatabaseInfo dbt types 0 0 (coerce tabInfos) MSSQL
 
 toCheckInfo :: Hints -> TableContent ColumnInfo -> [CheckCtx] -> TableContent CheckInfo
 toCheckInfo hints tcis = HM.fromListWith (++) . catMaybes . map chkInfo

--- a/dbrecord-mssql-odbc/src/DBRecord/MSSQL/Internal/Sql/Parser.hs
+++ b/dbrecord-mssql-odbc/src/DBRecord/MSSQL/Internal/Sql/Parser.hs
@@ -429,25 +429,41 @@ parseMSSQLType nullInfo sz = wrapNullable nullInfo . go
         go "nvarchar"                  = case szCharacterLength sz of
                                            Just v -> DBVarchar (Right v)
                                            _      -> error "Panic: varying character must specify a size" 
+        go "varchar"                   = case szCharacterLength sz of
+                                           Just v -> DBVarchar (Right v)
+                                           _      -> error "Panic: varying character must specify a size"                                            
         go "ntext"                     = DBText
         go "binary"                    = case szCharacterLength sz of -- TODO: Verify this check
                                            Just v -> DBBinary v
                                            _      -> error "Panic: Binary type must specify a size or length" 
         go "varbinary (max)"           = DBVarbinary (Left Type.Max)
         go "varbinary"                 = DBVarbinary (Left Type.Max) -- TODO : Check for sz part?
+        go "image"                     = DBVarbinary (Left Type.Max)
         go "datetimeoffset"            = case szDateTimePrecision sz of
                                            Just v  -> DBTimestamptz v
                                            Nothing -> DBTimestamptz 6
         go "datetime2"                 = case szDateTimePrecision sz of
                                            Just v  -> DBTimestamp v
                                            Nothing -> DBTimestamp 6
+        go "datetime"                 = case szDateTimePrecision sz of
+                                           Just v  -> DBTimestamp v
+                                           Nothing -> DBTimestamp 6 
+        go "smalldatetime"            = case szDateTimePrecision sz of
+                                           Just v  -> DBTimestamp v
+                                           Nothing -> DBTimestamp 6                                                                                      
         go "date"                      = DBDate
         go "time"                      = case szDateTimePrecision sz of
                                            Just v  -> DBTime v
                                            Nothing -> DBTime 6
         go "bit"                       = case szCharacterLength sz of
                                           Just v -> DBBit v
-                                          _      -> error "Panic: character must specify a size"
+                                          _      -> DBBit 1
+        go "tinyint"                   = DBInt2
+        go "smallmoney"                = DBText
+        go "money"                     = DBText
+        go "xml"                       = DBText
+        go "uniqueidentifier"          = DBUuid
+        go "char"                      = DBBinary 16
 
        -- Custom Type 
         go t                           = DBCustomType (DBTypeName (T.pack t) []) False

--- a/dbrecord-postgres-simple/src/DBRecord/Postgres/Internal/Reify.hs
+++ b/dbrecord-postgres-simple/src/DBRecord/Postgres/Internal/Reify.hs
@@ -44,6 +44,7 @@ import qualified DBRecord.Internal.Schema as S
 import qualified Data.HashMap.Strict as HM
 import DBRecord.Internal.Lens
 import Data.Int
+import DBRecord.Internal.Types
 
 data EnumInfo = EnumInfo { enumTypeName :: Text
                          , enumCons     :: Vector Text
@@ -149,7 +150,7 @@ toDatabaseInfo hints dbn eis cols chks defs pk uqs fks =
                                       , _ignoredCols    = ()
                                       }
                        ) tabNs
-  in mkDatabaseInfo dbt types 0 0 (coerce tabInfos)
+  in mkDatabaseInfo dbt types 0 0 (coerce tabInfos) Postgres
 
 toCheckInfo :: Hints -> TableContent ColumnInfo -> [CheckCtx] -> TableContent CheckInfo
 toCheckInfo hints tcis = HM.fromListWith (++) . catMaybes . map chkInfo

--- a/dbrecord/src/DBRecord/Internal/Expr.hs
+++ b/dbrecord/src/DBRecord/Internal/Expr.hs
@@ -778,3 +778,6 @@ toIdentity = unsafeCoerceExpr
 
 coerceExpr :: (Coercible a b) => Expr sc a -> Expr sc b
 coerceExpr = unsafeCoerceExpr
+
+rawExpr :: T.Text -> Expr sc a
+rawExpr = (Expr . PQ.RawExpr)

--- a/dbrecord/src/DBRecord/Internal/PrimQuery.hs
+++ b/dbrecord/src/DBRecord/Internal/PrimQuery.hs
@@ -204,6 +204,8 @@ data PrimExpr = AttrExpr Sym -- Eg?
               | AnonWindowExpr [PrimExpr] [OrderExpr] PrimExpr -- OVER
               | TableExpr PQFun PrimExpr
               | FlatComposite [Projection]
+            -- For Raw Expressions
+              | RawExpr T.Text
               deriving ({-Read,-} Show, Eq{-, Generic, Eq, Ord-})
 
 newtype PQFun = PQFun { getPqFun :: PrimExpr -> PrimQuery }

--- a/dbrecord/src/DBRecord/Internal/Sql/DML.hs
+++ b/dbrecord/src/DBRecord/Internal/Sql/DML.hs
@@ -168,8 +168,10 @@ data LitSql = NullSql
 
 
 data BinOp = OpEq | OpLt | OpLtEq | OpGt | OpGtEq | OpNotEq
+           | OpNotLt | OpNotGt
            | OpAnd | OpOr
            | OpLike | OpIn
+           | OpAny | OpAll | OpExists | OpSome | OpBetween
            | OpOther String  
            | OpCat
            | OpPlus | OpMinus | OpMul | OpDiv | OpMod
@@ -183,6 +185,8 @@ data UnOp = OpNot
           | OpLength
           | OpAbs
           | OpNegate
+          | OpPositive
+          | OpBitwiseNot
           | OpLower
           | OpUpper
           | OpOtherPrefix String

--- a/dbrecord/src/DBRecord/Internal/Types.hs
+++ b/dbrecord/src/DBRecord/Internal/Types.hs
@@ -51,6 +51,7 @@ data DbK = Postgres
          | Cassandra
          | Presto
          | MSSQL
+         deriving (Eq, Show)
 
 data Max = Max
          deriving (Show, Eq, Ord, Read)

--- a/stack.ghc-8.6.yaml
+++ b/stack.ghc-8.6.yaml
@@ -9,4 +9,4 @@ packages:
 - dbrecord-migration
 extra-deps: 
 - git: https://github.com/byteally/mssql-odbc.git
-  commit: b6340cfc33e45e33644479ad0cffb314f7da8904
+  commit: 593b59f4b3141439b6f1aecee72057ed431207db

--- a/stack.ghc-8.6.yaml
+++ b/stack.ghc-8.6.yaml
@@ -9,4 +9,4 @@ packages:
 - dbrecord-migration
 extra-deps: 
 - git: https://github.com/byteally/mssql-odbc.git
-  commit: 593b59f4b3141439b6f1aecee72057ed431207db
+  commit: 85658c0dda9bb257c3094c3f040b41e0ba96f580

--- a/stack.ghc-8.6.yaml
+++ b/stack.ghc-8.6.yaml
@@ -6,4 +6,7 @@ packages:
 - dbrecord-mongo
 - dbrecord-mssql-odbc
 - dbrecord-sqlite-simple
-extra-deps: []
+- dbrecord-migration
+extra-deps: 
+- git: https://github.com/byteally/mssql-odbc.git
+  commit: b6340cfc33e45e33644479ad0cffb314f7da8904


### PR DESCRIPTION
- Support for Checks & Defaults via Raw Expressions (RawExpr)
- Support for multiple schemas (each one generated in a separate directory with a different `Database.hs` )
- Support for generating identically common models/tables in `CommonModels` directory
- Support for square brackets when parsing variable/function names in sql expression (Ms-SQL syntax)
- Add Tests for sql expression (basic) parsing
- Add proper precedence (as per MS-SQL docs) for Binary expression evaluation/parsing.
- Add missing binary operator mappings 

Note : We are using byteally/mssql-odbc for all connections and for running all queries.
